### PR TITLE
Fixed "too many arguments" error and check that required software is present.

### DIFF
--- a/run_log
+++ b/run_log
@@ -145,7 +145,7 @@ temp_check()
     fi
     search_tsensors
     cur_temp=$(read_tsensors)
-    if [ $WRMON == "x" ]; then
+    if [ "$WRMON" == "x" ]; then
         WRMON=$(wrs_cmd "/wr/bin/wr_mon -wt")
     fi
     wrs_temp=$(echo $WRMON | grep -oh "FPGA.* PLL: [0-9]*.[0-9]*")

--- a/run_log
+++ b/run_log
@@ -250,6 +250,14 @@ ctrl_c()
 
 # -------------------------------------------
 
+# Check that all needed software is installed
+# else exit.
+check_sw()
+{
+    command -v bc >/dev/null 2>&1 || { echo >&2 "bc not installed. Will now exit."; exit 1; }
+    command -v sshpass >/dev/null 2>&1 || { echo >&2 "sshpass not installed. Will now exit."; exit 1; }
+}
+
 help()
 {
 cat << EOF
@@ -335,6 +343,8 @@ echo -e "\tConnecting to WRS ($REMOTE_ADDR)"
 if [ $HEADEREDOUT == 1 ]; then
     echo "# Epoch seconds $tempsensors $devtemp $synclabels"
 fi
+
+check_sw
 
 while true
 do


### PR DESCRIPTION
For an unknown reason, something like
`$variable="x"`
`if [ $variable == "x"]; then... `
failed and showed a "_too many arguments_" error. Double-quoting the variable prevents that.

Also, we now check that software like **bc** and **sshpass** is installed before attempting to use it. Otherwise, the script doesn't complain about the lack of sshpass.